### PR TITLE
fix: hotfix the RTD docs build failure caused by `sphinxtesters==0.2.3`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1203,8 +1203,8 @@ sphinxcontrib-qthelp==2.0.0 \
 sphinxcontrib-serializinghtml==2.0.0 \
     --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 \
     --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
-sphinxtesters==0.2.3 \
-    --hash=sha256:0b3a22cb299c48728759e3138edc2c5188f74d8e7fdd3cd57b307060ccea9d4c
+sphinxtesters==0.2.4 \
+    --hash=sha256:09c456e1cd61ec99b64851e2990d2152fdf05bb53d87f3b294f22d73f939d6ca
 stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695

--- a/pdm.lock
+++ b/pdm.lock
@@ -3008,11 +3008,15 @@ files = [
 
 [[package]]
 name = "sphinxtesters"
-version = "0.2.3"
+version = "0.2.4"
+requires_python = ">=3.8"
 summary = "Utilities for testing Sphinx extensions"
 groups = ["docs"]
+dependencies = [
+    "sphinx>=1.4",
+]
 files = [
-    {file = "sphinxtesters-0.2.3.tar.gz", hash = "sha256:0b3a22cb299c48728759e3138edc2c5188f74d8e7fdd3cd57b307060ccea9d4c"},
+    {file = "sphinxtesters-0.2.4.tar.gz", hash = "sha256:09c456e1cd61ec99b64851e2990d2152fdf05bb53d87f3b294f22d73f939d6ca"},
 ]
 
 [[package]]


### PR DESCRIPTION
* Fix the RTD docs build failure caused by `sphinxtesters` `v0.2.3`.